### PR TITLE
Configure password reset expiry and improve LDAP UID generation

### DIFF
--- a/server/src/Korga.Server/Configuration/LdapOptions.cs
+++ b/server/src/Korga.Server/Configuration/LdapOptions.cs
@@ -9,4 +9,5 @@ public class LdapOptions
     [Required] public string BindDn { get; set; } = null!;
     [Required] public string BindPassword { get; set; } = null!;
     [Required] public string BaseDn { get; set; } = null!;
+    [Range(0.25, 744.0)] public double PasswordResetExpiryHours { get; set; }
 }

--- a/server/src/Korga.Server/Program.cs
+++ b/server/src/Korga.Server/Program.cs
@@ -78,5 +78,6 @@ public class Program
                 services.AddKorgaOptions(context.Configuration);
                 services.AddSingleton<LdapService>();
                 services.AddKorgaMySqlDatabase();
+                services.AddTransient<LdapUidService>();
             });
 }

--- a/server/src/Korga.Server/Services/LdapUidService.cs
+++ b/server/src/Korga.Server/Services/LdapUidService.cs
@@ -1,0 +1,29 @@
+﻿using Korga.Server.Extensions;
+using System;
+
+namespace Korga.Server.Services;
+
+public class LdapUidService
+{
+	public string GetUid(string givenName, string familyName)
+	{
+		string normalizedGivenName = Normalize(givenName.ToLowerInvariant());
+		string normalizedFamilyName = Normalize(familyName.ToLowerInvariant());
+
+		return normalizedGivenName.Take(3) + normalizedFamilyName.Take(4);
+	}
+
+	private static string Normalize(string input)
+	{
+		return input
+			.Replace(" ", "", StringComparison.Ordinal)
+			.Replace("-", "", StringComparison.Ordinal)
+			.Replace("ä", "ae", StringComparison.Ordinal)
+			.Replace("é", "e", StringComparison.Ordinal)
+			.Replace("è", "e", StringComparison.Ordinal)
+			.Replace("ë", "e", StringComparison.Ordinal)
+			.Replace("ö", "oe", StringComparison.Ordinal)
+			.Replace("ü", "ue", StringComparison.Ordinal)
+			.Replace("ß", "ss", StringComparison.Ordinal);
+	}
+}

--- a/server/src/Korga.Server/appsettings.json
+++ b/server/src/Korga.Server/appsettings.json
@@ -10,7 +10,8 @@
     "Host": "localhost",
     "BindDn": "cn=admin,dc=example,dc=com",
     "BindPassword": "admin",
-    "BaseDn": "ou=members,dc=example,dc=com"
+    "BaseDn": "ou=members,dc=example,dc=com",
+    "PasswordResetExpiryHours": 48
   },
   "EmailRelay": {
     "Enable": false,

--- a/server/tests/Korga.Server.Tests/LdapUidServiceTests.cs
+++ b/server/tests/Korga.Server.Tests/LdapUidServiceTests.cs
@@ -1,0 +1,44 @@
+﻿using Korga.Server.Services;
+using Xunit;
+
+namespace Korga.Server.Tests;
+
+public class LdapUidServiceTests
+{
+	private readonly LdapUidService ldapUid;
+
+	public LdapUidServiceTests()
+	{
+		ldapUid = new LdapUidService();
+	}
+
+	[Fact]
+	public void StandardName()
+	{
+		Assert.Equal("maxmust", ldapUid.GetUid("Max", "Mustermann"));
+	}
+
+	[Fact]
+	public void WhiteSpaceFamilyName()
+	{
+		Assert.Equal("fravonb", ldapUid.GetUid("Franz", "von Baden"));
+	}
+
+	[Fact]
+	public void NonAsciiChars()
+	{
+		Assert.Equal("zoegrae", ldapUid.GetUid("Zoé", "Gräf"));
+	}
+
+	[Fact]
+	public void ShorterThanTemplate()
+	{
+		Assert.Equal("mado", ldapUid.GetUid("Ma", "Do"));
+	}
+
+	[Fact]
+	public void SpecialChars()
+	{
+		Assert.Equal("petborb", ldapUid.GetUid("Peter", "Bor-Buchholz"));
+	}
+}


### PR DESCRIPTION
This pull request add a configuration option to change the expiry time for password reset links. Furthermore, user IDs for LDAP are now better normalized and unit tested.