### PR TITLE
Delete processed emails from inbox after retention interval

### DIFF
--- a/server/src/Korga.Server/EmailRelay/EmailRelayOptions.cs
+++ b/server/src/Korga.Server/EmailRelay/EmailRelayOptions.cs
@@ -14,6 +14,7 @@ public class EmailRelayOptions
     [Required] public string ImapPassword { get; set; } = null!;
 
     [Range(0.0, 1440.0)] public double RetrievalIntervalInMinutes { get; set; }
+    [Range(0.0, 87600.0 /* max. 10 years */)] public double ImapRetentionIntervalInDays { get; set; }
     [Range(16, 1024)] public int MaxHeaderSizeInKilobytes { get; set; }
     [Range(64, 131072)] public int MaxBodySizeInKilobytes { get; set; }
 }

--- a/server/src/Korga.Server/appsettings.json
+++ b/server/src/Korga.Server/appsettings.json
@@ -37,6 +37,7 @@
     "ImapUsername": "catchall@example.org",
     "ImapPassword": "rVZKuee4p6BHJqYBWXmB",
     "RetrievalIntervalInMinutes": 2.0,
+    "ImapRetentionIntervalInDays": 1.0,
     "MaxHeaderSizeInKilobytes": 64,
     "MaxBodySizeInKilobytes": 12288
   },


### PR DESCRIPTION
This pull request adds a retention interval for emails. After that emails will be deleted from the IMAP inbox but still kept in the database. Emails that have not been handled by Korga will not be deleted.

A similar retention interval might be introduced for `InboxEmail` entities in the database in the future. It is not that urgent, however, because email inbox storage is usually much more expensive than disk storage on a server.