### PR TITLE
Send subject and from name in forward mode

### DIFF
--- a/server/src/Korga.Server/EmailRelay/EmailRelayJobController.cs
+++ b/server/src/Korga.Server/EmailRelay/EmailRelayJobController.cs
@@ -77,7 +77,7 @@ public class EmailRelayJobController : OneAtATimeJobController<InboxEmail>
         foreach (MailboxAddress address in recipients)
         {
             MimeMessage preparedMessage = distributionList.Flags.HasFlag(DistributionListFlags.Newsletter)
-                ? emailRelay.PrepareForForwardTo(email, address)
+                ? await emailRelay.PrepareForForwardTo(email, address, cancellationToken)
                 : emailRelay.PrepareForResentTo(email, address);
             await emailDelivery.Enqueue(address.Address, preparedMessage, email.Id, cancellationToken);
         }


### PR DESCRIPTION
This pull request fixes missing subjects (closes #23) and always sends a from name (closes #24) even if none was specified by the original author in forward mode.