### PR TITLE
DB optimization

### DIFF
--- a/server/src/Korga.Core/DatabaseContext.cs
+++ b/server/src/Korga.Core/DatabaseContext.cs
@@ -34,6 +34,7 @@ public sealed class DatabaseContext : DbContext
     public DbSet<PersonFilter> PersonFilters => Set<PersonFilter>();
 
     public DbSet<OutboxEmail> OutboxEmails => Set<OutboxEmail>();
+    public DbSet<SentEmail> SentEmails => Set<SentEmail>();
 
     public DbSet<PasswordReset> PasswordResets => Set<PasswordReset>();
 
@@ -115,6 +116,7 @@ public sealed class DatabaseContext : DbContext
         var inboxEmail = modelBuilder.Entity<InboxEmail>();
         inboxEmail.HasKey(e => e.Id);
         inboxEmail.HasOne(e => e.DistributionList).WithMany().HasForeignKey(e => e.DistributionListId);
+        inboxEmail.HasIndex(e => e.UniqueId).IsUnique();
         inboxEmail.HasIndex(e => e.ProcessingCompletedTime);
         inboxEmail.Property(e => e.DownloadTime).HasDefaultValueSql("CURRENT_TIMESTAMP(6)");
 
@@ -142,8 +144,13 @@ public sealed class DatabaseContext : DbContext
     {
         var outboxEmail = modelBuilder.Entity<OutboxEmail>();
         outboxEmail.HasKey(e => e.Id);
-        outboxEmail.HasOne(e => e.InboxEmail).WithMany(e => e.Recipients).HasForeignKey(e => e.InboxEmailId);
-        outboxEmail.HasIndex(e => e.DeliveryTime);
+        outboxEmail.HasOne(e => e.InboxEmail).WithMany().HasForeignKey(e => e.InboxEmailId);
+
+        var sentEmail = modelBuilder.Entity<SentEmail>();
+        sentEmail.HasKey(e => e.Id);
+        sentEmail.HasOne(e => e.InboxEmail).WithMany().HasForeignKey(e => e.InboxEmailId);
+        sentEmail.HasIndex(e => e.DeliveryTime);
+        sentEmail.Property(e => e.Id).ValueGeneratedNever();
     }
 
     private void CreateLdap(ModelBuilder modelBuilder)

--- a/server/src/Korga.Core/DatabaseContext.cs
+++ b/server/src/Korga.Core/DatabaseContext.cs
@@ -115,6 +115,7 @@ public sealed class DatabaseContext : DbContext
         var inboxEmail = modelBuilder.Entity<InboxEmail>();
         inboxEmail.HasKey(e => e.Id);
         inboxEmail.HasOne(e => e.DistributionList).WithMany().HasForeignKey(e => e.DistributionListId);
+        inboxEmail.HasIndex(e => e.ProcessingCompletedTime);
         inboxEmail.Property(e => e.DownloadTime).HasDefaultValueSql("CURRENT_TIMESTAMP(6)");
 
         var distributionList = modelBuilder.Entity<DistributionList>();
@@ -142,6 +143,7 @@ public sealed class DatabaseContext : DbContext
         var outboxEmail = modelBuilder.Entity<OutboxEmail>();
         outboxEmail.HasKey(e => e.Id);
         outboxEmail.HasOne(e => e.InboxEmail).WithMany(e => e.Recipients).HasForeignKey(e => e.InboxEmailId);
+        outboxEmail.HasIndex(e => e.DeliveryTime);
     }
 
     private void CreateLdap(ModelBuilder modelBuilder)

--- a/server/src/Korga.Core/EmailDelivery/Entities/OutboxEmail.cs
+++ b/server/src/Korga.Core/EmailDelivery/Entities/OutboxEmail.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Korga.EmailRelay.Entities;
+﻿using Korga.EmailRelay.Entities;
 
 namespace Korga.EmailDelivery.Entities;
 
@@ -18,6 +17,4 @@ public class OutboxEmail
 
     public string EmailAddress { get; set; }
     public byte[] Content { get; set; }
-    public string? ErrorMessage { get; set; }
-    public DateTime DeliveryTime { get; set; }
 }

--- a/server/src/Korga.Core/EmailDelivery/Entities/SentEmail.cs
+++ b/server/src/Korga.Core/EmailDelivery/Entities/SentEmail.cs
@@ -1,0 +1,17 @@
+﻿using Korga.EmailRelay.Entities;
+using System;
+
+namespace Korga.EmailDelivery.Entities;
+
+public class SentEmail
+{
+    public long Id { get; set; }
+
+    public long? InboxEmailId { get; set; }
+    public InboxEmail? InboxEmail { get; set; }
+
+    public required string EmailAddress { get; set; }
+    public int ContentSize { get; set; }
+    public string? ErrorMessage { get; set; }
+    public DateTime DeliveryTime { get; set; }
+}

--- a/server/src/Korga.Core/EmailRelay/Entities/InboxEmail.cs
+++ b/server/src/Korga.Core/EmailRelay/Entities/InboxEmail.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using Korga.EmailDelivery.Entities;
 
 namespace Korga.EmailRelay.Entities;
 
@@ -48,6 +46,4 @@ public class InboxEmail
     public byte[]? Body { get; set; }
     public DateTime DownloadTime { get; set; }
     public DateTime ProcessingCompletedTime { get; set; }
-
-    public IEnumerable<OutboxEmail>? Recipients { get; set; }
 }

--- a/server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.Designer.cs
+++ b/server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Korga;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Korga.Server.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230718214221_SplitOutboxEmail")]
+    partial class SplitOutboxEmail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.cs
+++ b/server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Korga.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class SplitOutboxEmail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SentEmails",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    InboxEmailId = table.Column<long>(type: "bigint", nullable: true),
+                    EmailAddress = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ContentSize = table.Column<int>(type: "int", nullable: false),
+                    ErrorMessage = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    DeliveryTime = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SentEmails", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SentEmails_InboxEmails_InboxEmailId",
+                        column: x => x.InboxEmailId,
+                        principalTable: "InboxEmails",
+                        principalColumn: "Id");
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxEmails_ProcessingCompletedTime",
+                table: "InboxEmails",
+                column: "ProcessingCompletedTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxEmails_UniqueId",
+                table: "InboxEmails",
+                column: "UniqueId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SentEmails_DeliveryTime",
+                table: "SentEmails",
+                column: "DeliveryTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SentEmails_InboxEmailId",
+                table: "SentEmails",
+                column: "InboxEmailId");
+
+            // Migrate archive data by creating new SentEmails for each OutboxEmails which has already been delivered.
+            migrationBuilder.Sql(
+@"INSERT INTO `SentEmails`
+(`Id`, `InboxEmailId`, `EmailAddress`, `ContentSize`, `ErrorMessage`, `DeliveryTime`)
+SELECT `Id`, `InboxEmailId`, `EmailAddress`, LENGTH(`Content`), `ErrorMessage`, `DeliveryTime`
+FROM `OutboxEmails`
+WHERE `DeliveryTime` <> ""0001-01-01 00:00:00""");
+
+            // Delete OutboxEmails which have already been delivered because their information is now stored in SentEmails.
+            migrationBuilder.Sql(
+@"DELETE FROM `OutboxEmails`
+WHERE `DeliveryTime` <> ""0001-01-01 00:00:00""");
+
+            migrationBuilder.DropColumn(
+                name: "DeliveryTime",
+                table: "OutboxEmails");
+
+            migrationBuilder.DropColumn(
+                name: "ErrorMessage",
+                table: "OutboxEmails");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SentEmails");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InboxEmails_ProcessingCompletedTime",
+                table: "InboxEmails");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InboxEmails_UniqueId",
+                table: "InboxEmails");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeliveryTime",
+                table: "OutboxEmails",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "ErrorMessage",
+                table: "OutboxEmails",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/server/src/Korga.Server/appsettings.json
+++ b/server/src/Korga.Server/appsettings.json
@@ -45,6 +45,7 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
+      "System": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     },
     "Console": {

--- a/server/tests/Korga.Server.Tests/Migrations/ForwardMode/DatabaseContext.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/ForwardMode/DatabaseContext.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Korga.Server.Tests.Migrations.ForwardMode;
+
+public class DatabaseContext : DbContext
+{
+    public DatabaseContext(DbContextOptions<DatabaseContext> options) : base(options) { }
+
+    public DbSet<OutboxEmail> OutboxEmails => Set<OutboxEmail>();
+}

--- a/server/tests/Korga.Server.Tests/Migrations/ForwardMode/OutboxEmail.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/ForwardMode/OutboxEmail.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Korga.Server.Tests.Migrations.ForwardMode;
+
+public class OutboxEmail
+{
+    public long Id { get; set; }
+
+    public long? InboxEmailId { get; set; }
+
+    public required string EmailAddress { get; set; }
+    public required byte[] Content { get; set; }
+    public string? ErrorMessage { get; set; }
+    public DateTime DeliveryTime { get; set; }
+}

--- a/server/tests/Korga.Server.Tests/Migrations/SplitOutboxEmail/DatabaseContext.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/SplitOutboxEmail/DatabaseContext.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Korga.Server.Tests.Migrations.SplitOutboxEmail;
+
+public class DatabaseContext : DbContext
+{
+    public DatabaseContext(DbContextOptions<DatabaseContext> options) : base(options) { }
+
+    public DbSet<OutboxEmail> OutboxEmails => Set<OutboxEmail>();
+    public DbSet<SentEmail> SentEmails => Set<SentEmail>();
+}

--- a/server/tests/Korga.Server.Tests/Migrations/SplitOutboxEmail/OutboxEmail.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/SplitOutboxEmail/OutboxEmail.cs
@@ -1,0 +1,11 @@
+﻿namespace Korga.Server.Tests.Migrations.SplitOutboxEmail;
+
+public class OutboxEmail
+{
+    public long Id { get; set; }
+
+    public long? InboxEmailId { get; set; }
+
+    public required string EmailAddress { get; set; }
+    public required byte[] Content { get; set; }
+}

--- a/server/tests/Korga.Server.Tests/Migrations/SplitOutboxEmail/SentEmail.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/SplitOutboxEmail/SentEmail.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Korga.Server.Tests.Migrations.SplitOutboxEmail;
+
+public class SentEmail
+{
+    public long Id { get; set; }
+
+    public long? InboxEmailId { get; set; }
+
+    public required string EmailAddress { get; set; }
+    public int ContentSize { get; set; }
+    public string? ErrorMessage { get; set; }
+    public DateTime DeliveryTime { get; set; }
+}

--- a/server/tests/Korga.Server.Tests/Migrations/SplitOutboxEmailMigrationTests.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/SplitOutboxEmailMigrationTests.cs
@@ -1,0 +1,155 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using MySqlConnector;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using ForwardMode_DbContext = Korga.Server.Tests.Migrations.ForwardMode.DatabaseContext;
+using ForwardMode_OutboxEmail = Korga.Server.Tests.Migrations.ForwardMode.OutboxEmail;
+using SplitOutboxEmail_DbContext = Korga.Server.Tests.Migrations.SplitOutboxEmail.DatabaseContext;
+using SplitOutboxEmail_OutboxEmail = Korga.Server.Tests.Migrations.SplitOutboxEmail.OutboxEmail;
+using SplitOutboxEmail_SentEmail = Korga.Server.Tests.Migrations.SplitOutboxEmail.SentEmail;
+
+namespace Korga.Server.Tests.Migrations;
+
+public class SplitOutboxEmailMigrationTests : MigrationTest
+{
+    private const string outboxEmail1_EmailAddress = "alice@example.org";
+    private readonly byte[] outboxEmail1_Content = Encoding.ASCII.GetBytes("");
+    private readonly DateTime outboxEmail1_DeliveryTime = DateTime.Parse("2023-08-13 18:57:21");
+    private const string outboxEmail2_EmailAddress = "bob@example.org";
+    private readonly byte[] outboxEmail2_Content = Encoding.ASCII.GetBytes("");
+
+    private readonly ForwardMode_DbContext forwardMode;
+    private readonly SplitOutboxEmail_DbContext splitOutboxEmail;
+
+    public SplitOutboxEmailMigrationTests() : base("SplitOutboxEmailMigration")
+    {
+        forwardMode = serviceScope.ServiceProvider.GetRequiredService<ForwardMode_DbContext>();
+        splitOutboxEmail = serviceScope.ServiceProvider.GetRequiredService<SplitOutboxEmail_DbContext>();
+    }
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddDbContext<ForwardMode_DbContext>(
+            optionsBuilder => optionsBuilder.UseMySql(connectionString, ServerVersion.AutoDetect(shortConnectionString)));
+
+        services.AddDbContext<SplitOutboxEmail_DbContext>(
+            optionsBuilder => optionsBuilder.UseMySql(connectionString, ServerVersion.AutoDetect(shortConnectionString)));
+    }
+
+    [Fact]
+    public async Task TestUpgrade()
+    {
+        ForwardMode_OutboxEmail beforeMigrationSent = new()
+        {
+            InboxEmailId = null,
+            EmailAddress = outboxEmail1_EmailAddress,
+            Content = outboxEmail1_Content,
+            DeliveryTime = outboxEmail1_DeliveryTime,
+            ErrorMessage = ""
+        };
+        SplitOutboxEmail_SentEmail expectedSent = new()
+        {
+            Id = 1,
+            InboxEmailId = null,
+            EmailAddress = outboxEmail1_EmailAddress,
+            ContentSize = outboxEmail1_Content.Length,
+            DeliveryTime = outboxEmail1_DeliveryTime,
+            ErrorMessage = ""
+        };
+        ForwardMode_OutboxEmail beforeMigrationPending = new()
+        {
+            InboxEmailId = null,
+            EmailAddress = outboxEmail2_EmailAddress,
+            Content = outboxEmail2_Content,
+            DeliveryTime = default,
+            ErrorMessage = null
+        };
+        SplitOutboxEmail_OutboxEmail expectedPending = new()
+        {
+            Id = 2,
+            InboxEmailId = null,
+            EmailAddress = outboxEmail2_EmailAddress,
+            Content = outboxEmail2_Content
+        };
+
+        IMigrator migrator = databaseContext.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        // Create database schema of last migration before the one to test
+        await migrator.MigrateAsync("ForwardMode");
+
+        // Add test data
+        forwardMode.OutboxEmails.Add(beforeMigrationSent);
+        forwardMode.OutboxEmails.Add(beforeMigrationPending);
+        await forwardMode.SaveChangesAsync();
+
+        // Run migration at test
+        await migrator.MigrateAsync("SplitOutboxEmail");
+
+        // Verify that data has been migrated as expected
+        SplitOutboxEmail_SentEmail sentEmail = await splitOutboxEmail.SentEmails.SingleAsync();
+        SplitOutboxEmail_OutboxEmail outboxEmail = await splitOutboxEmail.OutboxEmails.SingleAsync();
+
+        Assert.Equivalent(expectedSent, sentEmail);
+        Assert.Equivalent(expectedPending, outboxEmail);
+    }
+
+    [Fact]
+    public async Task TestDowngrade()
+    {
+        SplitOutboxEmail_SentEmail beforeDowngradeSent = new()
+        {
+            Id = 1,
+            InboxEmailId = null,
+            EmailAddress = outboxEmail1_EmailAddress,
+            ContentSize = outboxEmail1_Content.Length,
+            DeliveryTime = outboxEmail1_DeliveryTime,
+            ErrorMessage = ""
+        };
+        SplitOutboxEmail_OutboxEmail beforeDowngradePending = new()
+        {
+            Id = 2,
+            InboxEmailId = null,
+            EmailAddress = outboxEmail2_EmailAddress,
+            Content = outboxEmail2_Content
+        };
+        ForwardMode_OutboxEmail expectedPending = new()
+        {
+            Id = 2,
+            InboxEmailId = null,
+            EmailAddress = outboxEmail2_EmailAddress,
+            Content = outboxEmail2_Content,
+            DeliveryTime = default,
+            ErrorMessage = null
+        };
+
+        IMigrator migrator = databaseContext.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        // Create database schema of the migration to test
+        await migrator.MigrateAsync("SplitOutboxEmail");
+
+        // Add test data
+        splitOutboxEmail.SentEmails.Add(beforeDowngradeSent);
+        splitOutboxEmail.OutboxEmails.Add(beforeDowngradePending);
+        await splitOutboxEmail.SaveChangesAsync();
+
+        // Migrate to migration before the one to test and thereby revert it
+        await migrator.MigrateAsync("ForwardMode");
+
+        // Verify that data has been rolled back as expected
+        ForwardMode_OutboxEmail outboxEmail = await forwardMode.OutboxEmails.SingleAsync();
+        Assert.Equivalent(expectedPending, outboxEmail);
+
+        // Make sure old table has been deleted
+        await using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText = $"SHOW TABLES WHERE `Tables_in_{databaseName}` = \"SentEmails\"";
+            await using MySqlDataReader reader = await command.ExecuteReaderAsync();
+            Assert.False(await reader.ReadAsync());
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds missing indices to fix extremely long query execution times of more than 30 seconds to fetch the next item from _OutboxEmails_. It also moves all statistic data from _OutboxEmail_ to _SentEmails_ to address #27.

Binary contents for outgoing emails are therefore no longer preserved which massively decreases database size. Currently all emails Korga every sent for every single recipient are being kept which quickly adds up to multiple gigabyte large tables.

Note to reviewers: Generated code for migrations does not have to be inspected except for `server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.cs` lines 59-70.