### PR TITLE
Migrate database on startup

### DIFF
--- a/server/src/Korga.Server/Configuration/DatabaseOptions.cs
+++ b/server/src/Korga.Server/Configuration/DatabaseOptions.cs
@@ -6,4 +6,5 @@ public class DatabaseOptions
 {
     // Validation ensures that required values cannot be null
     [Required] public string ConnectionString { get; set; } = null!;
+    public bool MigrateOnStartup { get; set; }
 }

--- a/server/src/Korga.Server/Extensions/HostExtensions.cs
+++ b/server/src/Korga.Server/Extensions/HostExtensions.cs
@@ -1,0 +1,38 @@
+﻿using Korga.Server.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Korga.Server.Extensions;
+
+public static class HostExtensions
+{
+    public static IHost MigrateDatabase(this IHost host)
+    {
+        var options = host.Services.GetRequiredService<IOptions<DatabaseOptions>>();
+
+        if (options.Value.MigrateOnStartup)
+        {
+            using IServiceScope scope = host.Services.CreateScope();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+            var database = scope.ServiceProvider.GetRequiredService<DatabaseContext>();
+
+            IEnumerable<string> pendingMigrations = database.Database.GetPendingMigrations();
+            if (pendingMigrations.Any())
+            {
+                logger.LogInformation("Applying the following migrations: {Migrations}", string.Join(", ", pendingMigrations));
+                database.Database.Migrate();
+            }
+            else
+            {
+                logger.LogInformation("Database migration on startup is enabled: No pending migrations");
+            }
+        }
+
+        return host;
+    }
+}

--- a/server/src/Korga.Server/Program.cs
+++ b/server/src/Korga.Server/Program.cs
@@ -27,7 +27,11 @@ public class Program
 #endif
         if (args.Length == 0)
         {
-            await CreateWebHostBuilder(args).Build().RunAsync();
+            await CreateWebHostBuilder(args).Build()
+                // Automatic database migration is done here right after building the host and not in Startup.Configure
+                // to make sure no other other hosted services can start while migrations are not yet completed.
+                .MigrateDatabase()
+                .RunAsync();
             return Environment.ExitCode;
         }
         else

--- a/server/src/Korga.Server/appsettings.Development.json
+++ b/server/src/Korga.Server/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Database": {
+    "MigrateOnStartup": false
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/server/src/Korga.Server/appsettings.json
+++ b/server/src/Korga.Server/appsettings.json
@@ -1,6 +1,7 @@
 {
   "Database": {
-    "ConnectionString": "Server=localhost;Port=3306;Database=korga;User=root;Password=root;"
+    "ConnectionString": "Server=localhost;Port=3306;Database=korga;User=root;Password=root;",
+    "MigrateOnStartup": true
   },
   "Hosting": {
     "PathBase": null,


### PR DESCRIPTION
This pull requests adds automatic database migration on startup.

This feature will be enabled by default except for development mode. Updates with database schema changes will then no longer require attention of server administrators.

Migrations that might result in data loss like from Korga v1.0.1 to Korga v2.0.0 will be released as a new major version number with warnings in the release notes about which conditions must be met to prevent data loss.