### PR TITLE
Add unit tests for database migrations

### DIFF
--- a/server/tests/Korga.Server.Tests/Migrations/AddSinglePersonFilter/DatabaseContext.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/AddSinglePersonFilter/DatabaseContext.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Korga.Server.Tests.Migrations.AddSinglePersonFilter;
+
+public class DatabaseContext : DbContext
+{
+    public DatabaseContext(DbContextOptions<DatabaseContext> options) : base(options) { }
+
+    public DbSet<Email> Emails => Set<Email>();
+}

--- a/server/tests/Korga.Server.Tests/Migrations/AddSinglePersonFilter/Email.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/AddSinglePersonFilter/Email.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Korga.Server.Tests.Migrations.AddSinglePersonFilter;
+
+public class Email
+{
+    public long Id { get; set; }
+
+    public long? DistributionListId { get; set; }
+
+    public required string Subject { get; set; }
+    public required string From { get; set; }
+    public string? Sender { get; set; }
+    public required string To { get; set; }
+    public string? Receiver { get; set; }
+    public required byte[] Body { get; set; }
+    public DateTime DownloadTime { get; set; }
+    public DateTime RecipientsFetchTime { get; set; }
+}

--- a/server/tests/Korga.Server.Tests/Migrations/InboxOutbox/DatabaseContext.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/InboxOutbox/DatabaseContext.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Korga.Server.Tests.Migrations.InboxOutbox;
+
+public class DatabaseContext : DbContext
+{
+    public DatabaseContext(DbContextOptions<DatabaseContext> options) : base(options) { }
+
+    public DbSet<InboxEmail> InboxEmails => Set<InboxEmail>();
+}

--- a/server/tests/Korga.Server.Tests/Migrations/InboxOutbox/InboxEmail.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/InboxOutbox/InboxEmail.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Korga.Server.Tests.Migrations.InboxOutbox;
+
+public class InboxEmail
+{
+    public long Id { get; set; }
+
+    public long? DistributionListId { get; set; }
+
+    public uint UniqueId { get; set; }
+    public required string Subject { get; set; }
+    public required string From { get; set; }
+    public string? Sender { get; set; }
+    public string? ReplyTo { get; set; }
+    public required string To { get; set; }
+    public string? Receiver { get; set; }
+    public byte[]? Header { get; set; }
+    public byte[]? Body { get; set; }
+    public DateTime DownloadTime { get; set; }
+    public DateTime ProcessingCompletedTime { get; set; }
+}

--- a/server/tests/Korga.Server.Tests/Migrations/InboxOutboxMigrationTests.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/InboxOutboxMigrationTests.cs
@@ -1,0 +1,268 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using MySqlConnector;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Korga.Server.Tests.Migrations;
+
+/// <summary>
+/// These tests focus on breaking database schema changes
+/// that would result in data loss if not handled manually.
+/// 
+/// Non-breaking changes like creating columns are handled by generated code
+/// which is covered by Microsoft's unit tests.
+/// </summary>
+public class InboxOutboxMigrationTests : IDisposable
+{
+    private const string databaseName = "Korga_InboxOutboxMigration";
+    private const string shortConnectionString = "Server=localhost;Port=3306;User=root;Password=root;";
+    private const string connectionString = $"Server=localhost;Port=3306;Database={databaseName};User=root;Password=root;";
+
+    private const uint inboxEmail_UniqueId = 573;
+    private const string inboxEmail_Subject = "Korga is amazing!";
+    private const string inboxEmail_From = "Alice <alice@example.org>";
+    private const string inboxEmail_To = "<admin@example.org>";
+    private const string inboxEmail_Receiver = "admin@example.org";
+    private static readonly byte[] inboxEmail_Header = Encoding.ASCII.GetBytes(
+@"X-Envelope-From: <alice@example.org>
+X-Envelope-To: <admin@example.org>
+X-Delivery-Time: 1691127648
+X-UID: 573
+Return-Path: <alice@example.org>
+Received: from mo4-p07-ob.smtp.rzone.de ([85.215.255.115])
+    by smtpin.rzone.de (RZmta 49.6.6 OK)
+    with ESMTPS id x94474z745emBAI
+    (using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256 bits))
+    (Client CN ""*.smtp.rzone.de"", Issuer ""Telekom Security ServerID OV Class 2 CA"" (verified OK (+EmiG)))
+        (Client hostname verified OK)
+    for <admin@example.org>;
+    Fri, 4 Aug 2023 07:40:48 +0200 (CEST)
+Received: from Daniel
+    by smtp.strato.de (RZmta 49.6.6 AUTH)
+    with ESMTPSA id jbaa7fz745elswK
+        (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256 bits))
+        (Client did not present a certificate)
+    for <admin@example.org>;
+    Fri, 4 Aug 2023 07:40:47 +0200 (CEST)
+From: Alice <alice@example.org>
+To: <admin@example.org>
+Subject: Korga is amazing!
+Date: Thu, 3 Aug 2023 22:40:54 -0700
+Message-ID: <000601d9c696$3d776850$b86638f0$@lerchen.net>
+MIME-Version: 1.0
+Content-Type: text/plain;
+        charset=""us-ascii""
+Content-Transfer-Encoding: 7bit
+X-Mailer: Microsoft Outlook 16.0
+Thread-Index: AdnGlciACcvt+J5wRaKLB5djqUAoHw==
+Content-Language: de");
+    private static readonly byte[] inboxEmail_Body = Encoding.ASCII.GetBytes(
+@"Content-Type: text/plain;
+        charset=""us-ascii""
+Content-Transfer-Encoding: 7bit
+Content-Language: en
+
+Hey,
+are you using ChurchTools in your church and have been wondering whether
+email distribution lists can be done easier? Korga is what you need. It
+imports person data and groups from ChurchTools and offers distribution
+lists that you can send emails to from your favorite client like
+youth@example.org.
+Cheers,
+Daniel");
+    private static readonly DateTime inboxEmail_DownloadTime = DateTime.Parse("2023-08-03 22:42:00.797007");
+    private static readonly DateTime inboxEmail_ProcessingCompletedTime = DateTime.Parse("2023-08-04 05:42:00.881735");
+
+    private readonly MySqlConnection connection;
+    private readonly ServiceProvider serviceProvider;
+    private readonly IServiceScope serviceScope;
+    private readonly DatabaseContext databaseContext;
+
+    public InboxOutboxMigrationTests()
+    {
+        // Create test database
+        connection = new(shortConnectionString);
+        connection.Open();
+        CreateEmptyDatabase(connection, databaseName);
+        connection.ChangeDatabase(databaseName);
+
+        // Create DatabaseContext for migrations
+        serviceProvider = new ServiceCollection()
+            .AddDbContext<DatabaseContext>(optionsBuilder =>
+            {
+                optionsBuilder.UseMySql(
+                    connectionString,
+                    ServerVersion.AutoDetect(shortConnectionString),
+                    builder =>
+                    {
+                        builder.MigrationsAssembly($"{nameof(Korga)}.{nameof(Server)}");
+                        builder.EnableRetryOnFailure();
+                    });
+            })
+            .BuildServiceProvider();
+
+        serviceScope = serviceProvider.CreateScope();
+        databaseContext = serviceScope.ServiceProvider.GetRequiredService<DatabaseContext>();
+    }
+
+    public void Dispose()
+    {
+        serviceScope.Dispose();
+        serviceProvider.Dispose();
+
+        //DropDatabase(connection, databaseName);
+
+        connection.Close();
+        connection.Dispose();
+    }
+
+    /// <summary>
+    /// Tests custom migration code from Emails table to InboxEmails.
+    /// </summary>
+    /// <remarks>
+    /// The migration InboxOutbox renamed the Emails table to InboxEmails
+    /// and replaced the EmailRecipients table with OutboxEmails.
+    /// 
+    /// Received emails from the Emails table must be preversed
+    /// whereas sent and unsent emails from EmailRecipients table are discarded.
+    /// </remarks> 
+    [Fact]
+    public async Task TestUpgrade()
+    {
+        IMigrator migrator = databaseContext.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        // Create database schema of last migration before the one to test
+        await migrator.MigrateAsync("AddSinglePersonFilter");
+
+        // Add test data
+        using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText =
+@"INSERT INTO `Emails`
+(`DistributionListId`, `Subject`, `From`, `Sender`, `To`, `Receiver`, `Body`, `DownloadTime`, `RecipientsFetchTime`)
+VALUES (NULL, @subject, @from, NULL, @to, @receiver, @body, @downloadtime, @completedtime)
+";
+            command.Parameters.AddWithValue("@subject", inboxEmail_Subject);
+            command.Parameters.AddWithValue("@from", inboxEmail_From);
+            command.Parameters.AddWithValue("@to", inboxEmail_To);
+            command.Parameters.AddWithValue("@receiver", inboxEmail_Receiver);
+            command.Parameters.AddWithValue("@body", inboxEmail_Body);
+            command.Parameters.AddWithValue("@downloadtime", inboxEmail_DownloadTime);
+            command.Parameters.AddWithValue("@completedtime", inboxEmail_ProcessingCompletedTime);
+
+            Assert.Equal(1, await command.ExecuteNonQueryAsync());
+        }
+
+        // Run migration at test
+        await migrator.MigrateAsync("InboxOutbox");
+
+        // Verify that data has been migrated as expected
+        using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText =
+@"SELECT `DistributionListId`, `UniqueId`, `Subject`, `From`, `Sender`, `ReplyTo`, `To`, `Receiver`, `Header`, `Body`, `DownloadTime`, `ProcessingCompletedTime`
+FROM `InboxEmails`";
+            MySqlDataReader reader = await command.ExecuteReaderAsync();
+            Assert.True(await reader.ReadAsync());
+            Assert.True(reader.IsDBNull(0));
+            Assert.Equal(0u, reader.GetUInt32(1));
+            Assert.Equal(inboxEmail_Subject, reader.GetString(2));
+            Assert.Equal(inboxEmail_From, reader.GetString(3));
+            Assert.True(reader.IsDBNull(4));
+            Assert.True(reader.IsDBNull(5));
+            Assert.Equal(inboxEmail_To, reader.GetString(6));
+            Assert.Equal(inboxEmail_Receiver, reader.GetString(7));
+            Assert.True(reader.IsDBNull(8));
+            Assert.Equal(inboxEmail_Body, (byte[])reader.GetValue(9));
+            Assert.Equal(inboxEmail_DownloadTime, reader.GetDateTime(10));
+            Assert.Equal(inboxEmail_ProcessingCompletedTime, reader.GetDateTime(11));
+        }
+    }
+
+    /// <summary>
+    /// Tests custom rollback code from InboxEmails table to Emails.
+    /// </summary>
+    /// <remarks>
+    /// The migration InboxOutbox renamed the Emails table to InboxEmails
+    /// and replaced the EmailRecipients table with OutboxEmails.
+    /// 
+    /// Received emails from the Emails table must be preversed
+    /// whereas sent and unsent emails from EmailRecipients table are discarded.
+    /// </remarks> 
+    [Fact]
+    public async Task TestDowngrade()
+    {
+        IMigrator migrator = databaseContext.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        // Create database schema of the migration to test
+        await migrator.MigrateAsync("InboxOutbox");
+        
+        // Add test data
+        using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText =
+@"INSERT INTO `InboxEmails`
+(`DistributionListId`, `UniqueId`, `Subject`, `From`, `Sender`, `ReplyTo`, `To`, `Receiver`, `Header`, `Body`, `DownloadTime`, `ProcessingCompletedTime`)
+VALUES (NULL, @uniqueid, @subject, @from, NULL, NULL, @to, @receiver, @header, @body, @downloadtime, @completedtime)";
+            command.Parameters.AddWithValue("@uniqueid", inboxEmail_UniqueId);
+            command.Parameters.AddWithValue("@subject", inboxEmail_Subject);
+            command.Parameters.AddWithValue("@from", inboxEmail_From);
+            command.Parameters.AddWithValue("@to", inboxEmail_To);
+            command.Parameters.AddWithValue("@receiver", inboxEmail_Receiver);
+            command.Parameters.AddWithValue("@header", inboxEmail_Header);
+            command.Parameters.AddWithValue("@body", inboxEmail_Body);
+            command.Parameters.AddWithValue("@downloadtime", inboxEmail_DownloadTime);
+            command.Parameters.AddWithValue("@completedtime", inboxEmail_ProcessingCompletedTime);
+
+            Assert.Equal(1, await command.ExecuteNonQueryAsync());
+        }
+
+        // Migrate to migration before the one to test and thereby revert it
+        await migrator.MigrateAsync("AddSinglePersonFilter");
+
+        // Verify that data has been rolled back as expected
+        using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText =
+@"SELECT `DistributionListId`, `Subject`, `From`, `Sender`, `To`, `Receiver`, `Body`, `DownloadTime`, `RecipientsFetchTime`
+FROM `Emails`";
+            MySqlDataReader reader = await command.ExecuteReaderAsync();
+            Assert.True(await reader.ReadAsync());
+            Assert.True(reader.IsDBNull(0));
+            Assert.Equal(inboxEmail_Subject, reader.GetString(1));
+            Assert.Equal(inboxEmail_From, reader.GetString(2));
+            Assert.True(reader.IsDBNull(3));
+            Assert.Equal(inboxEmail_To, reader.GetString(4));
+            Assert.Equal(inboxEmail_Receiver, reader.GetString(5));
+            Assert.Equal(inboxEmail_Body, (byte[])reader.GetValue(6));
+            Assert.Equal(inboxEmail_DownloadTime, reader.GetDateTime(7));
+            Assert.Equal(inboxEmail_ProcessingCompletedTime, reader.GetDateTime(8));
+        }
+    }
+
+    private static void CreateEmptyDatabase(MySqlConnection connection, string databaseName)
+    {
+        using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText = $"DROP DATABASE IF EXISTS {databaseName}";
+            command.ExecuteNonQuery();
+        }
+        using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText = $"CREATE DATABASE {databaseName}";
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private static void DropDatabase(MySqlConnection connection, string databaseName)
+    {
+        using MySqlCommand command = connection.CreateCommand();
+        command.CommandText = $"DROP DATABASE {databaseName}";
+        command.ExecuteNonQuery();
+    }
+}

--- a/server/tests/Korga.Server.Tests/Migrations/MigrationTest.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/MigrationTest.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MySqlConnector;
+using System;
+
+namespace Korga.Server.Tests.Migrations;
+
+public abstract class MigrationTest : IDisposable
+{
+    private readonly ServiceProvider serviceProvider;
+    private readonly IServiceScope serviceScope;
+
+    protected readonly string databaseName;
+    protected readonly MySqlConnection connection;
+    protected readonly DatabaseContext databaseContext;
+
+    public MigrationTest(string testName)
+    {
+        databaseName = $"Korga_{testName}";
+        string shortConnectionString = "Server=localhost;Port=3306;User=root;Password=root;";
+        string connectionString = $"Server=localhost;Port=3306;Database={databaseName};User=root;Password=root;";
+
+        // Create test database
+        connection = new(shortConnectionString);
+        connection.Open();
+        CreateEmptyDatabase(connection, databaseName);
+        connection.ChangeDatabase(databaseName);
+
+        // Create DatabaseContext for migrations
+        serviceProvider = new ServiceCollection()
+            .AddDbContext<DatabaseContext>(optionsBuilder =>
+            {
+                optionsBuilder.UseMySql(
+                    connectionString,
+                    ServerVersion.AutoDetect(shortConnectionString),
+                    builder =>
+                    {
+                        builder.MigrationsAssembly($"{nameof(Korga)}.{nameof(Server)}");
+                        builder.EnableRetryOnFailure();
+                    });
+            })
+            .BuildServiceProvider();
+
+        serviceScope = serviceProvider.CreateScope();
+        databaseContext = serviceScope.ServiceProvider.GetRequiredService<DatabaseContext>();
+    }
+
+    public void Dispose()
+    {
+        serviceScope.Dispose();
+        serviceProvider.Dispose();
+
+        DropDatabase(connection, databaseName);
+
+        connection.Close();
+        connection.Dispose();
+    }
+
+    private static void CreateEmptyDatabase(MySqlConnection connection, string databaseName)
+    {
+        using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText = $"DROP DATABASE IF EXISTS {databaseName}";
+            command.ExecuteNonQuery();
+        }
+        using (MySqlCommand command = connection.CreateCommand())
+        {
+            command.CommandText = $"CREATE DATABASE {databaseName}";
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private static void DropDatabase(MySqlConnection connection, string databaseName)
+    {
+        using MySqlCommand command = connection.CreateCommand();
+        command.CommandText = $"DROP DATABASE {databaseName}";
+        command.ExecuteNonQuery();
+    }
+}

--- a/server/tests/Korga.Server.Tests/Migrations/MigrationTest.cs
+++ b/server/tests/Korga.Server.Tests/Migrations/MigrationTest.cs
@@ -52,7 +52,7 @@ public abstract class MigrationTest : IDisposable
         serviceScope.Dispose();
         serviceProvider.Dispose();
 
-        //DropDatabase(connection, databaseName);
+        DropDatabase(connection, databaseName);
 
         connection.Close();
         connection.Dispose();


### PR DESCRIPTION
This pull request add two unit tests for the only database migration with custom SQL. It is intended as a blueprint for future migration unit tests. Tests include database upgrade and rollback using a single representative entity. Coverage is not perfect as not all nullability combinations for columns can be checked this way but I still consider it a big step towards better unit test coverage.

Compared to other C# code in Korga it is extremely verbose because it uses hand coded SQL queries instead of EF Core objective-relational mapper. However, to use EF Core I would have to copy all entity classes for every migration to able to work with old entity schemas. Despite their verbosity, direct SQL queries seemed to be a more elegant solution to me.