### PR TITLE
Fix unique constraint violation at DB migration

### DIFF
--- a/server/src/Korga.Core/EmailRelay/Entities/InboxEmail.cs
+++ b/server/src/Korga.Core/EmailRelay/Entities/InboxEmail.cs
@@ -4,7 +4,7 @@ namespace Korga.EmailRelay.Entities;
 
 public class InboxEmail
 {
-    public InboxEmail(uint uniqueId, string subject, string from, string? sender, string? replyTo, string to, string? receiver, byte[]? header, byte[]? body)
+    public InboxEmail(uint? uniqueId, string subject, string from, string? sender, string? replyTo, string to, string? receiver, byte[]? header, byte[]? body)
     {
         UniqueId = uniqueId;
         Subject = subject;
@@ -22,7 +22,7 @@ public class InboxEmail
     public long? DistributionListId { get; set; }
     public DistributionList? DistributionList { get; set; }
 
-    public uint UniqueId { get; set; }
+    public uint? UniqueId { get; set; }
     public string Subject { get; set; }
     public string From { get; set; }
     public string? Sender { get; set; }

--- a/server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.Designer.cs
+++ b/server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.Designer.cs
@@ -282,7 +282,7 @@ namespace Korga.Server.Migrations
                         .IsRequired()
                         .HasColumnType("longtext");
 
-                    b.Property<uint>("UniqueId")
+                    b.Property<uint?>("UniqueId")
                         .HasColumnType("int unsigned");
 
                     b.HasKey("Id");

--- a/server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.cs
+++ b/server/src/Korga.Server/Migrations/20230718214221_SplitOutboxEmail.cs
@@ -35,6 +35,17 @@ namespace Korga.Server.Migrations
                 })
                 .Annotation("MySql:CharSet", "utf8mb4");
 
+            // Make UniqueId column nullable and change zero values to NULL to avoid conflicts when creating a unqiue index later
+            migrationBuilder.AlterColumn<uint?>(
+                name: "UniqueId",
+                table: "InboxEmails",
+                type: "int unsigned",
+                nullable: true,
+                oldClrType: typeof(uint),
+                oldType: "int unsigned");
+
+            migrationBuilder.Sql("UPDATE `InboxEmails` SET `UniqueId` = NULL WHERE `UniqueId` = 0");
+
             migrationBuilder.CreateIndex(
                 name: "IX_InboxEmails_ProcessingCompletedTime",
                 table: "InboxEmails",
@@ -91,6 +102,16 @@ WHERE `DeliveryTime` <> ""0001-01-01 00:00:00""");
             migrationBuilder.DropIndex(
                 name: "IX_InboxEmails_UniqueId",
                 table: "InboxEmails");
+
+            migrationBuilder.AlterColumn<uint>(
+                name: "UniqueId",
+                table: "InboxEmails",
+                type: "int unsigned",
+                nullable: false,
+                defaultValue: 0u,
+                oldClrType: typeof(uint),
+                oldType: "int unsigned",
+                oldNullable: false);
 
             migrationBuilder.AddColumn<DateTime>(
                 name: "DeliveryTime",

--- a/server/src/Korga.Server/Migrations/20230823082608_GroupStatus.Designer.cs
+++ b/server/src/Korga.Server/Migrations/20230823082608_GroupStatus.Designer.cs
@@ -322,7 +322,7 @@ namespace Korga.Server.Migrations
                         .IsRequired()
                         .HasColumnType("longtext");
 
-                    b.Property<uint>("UniqueId")
+                    b.Property<uint?>("UniqueId")
                         .HasColumnType("int unsigned");
 
                     b.HasKey("Id");

--- a/server/src/Korga.Server/Migrations/DatabaseContextModelSnapshot.cs
+++ b/server/src/Korga.Server/Migrations/DatabaseContextModelSnapshot.cs
@@ -319,7 +319,7 @@ namespace Korga.Server.Migrations
                         .IsRequired()
                         .HasColumnType("longtext");
 
-                    b.Property<uint>("UniqueId")
+                    b.Property<uint?>("UniqueId")
                         .HasColumnType("int unsigned");
 
                     b.HasKey("Id");


### PR DESCRIPTION
This pull request fixes a fatal unique constraint exception during the `SplitOutboxEmail` migration. That was caused by duplicate `0` values in `InboxEmail.UniqueId` as this column was added after Korga's first release.

To fix the migration this pull request is bit messy. It changes two existing migrations in such a way that `UniqueId` becomes nullable and has `NULL` as its default value instead of `0`.

Changing migrations after the release of Korga 2.1.0 is not very elegant because it will lead to problems for those users who already have migrated successfully but is difficult to fix otherwise. As Korga 2.1.0 has not been released for a long time and I don't know about any other production users besides our church, I would take this risk.