### PR TITLE
Fix outbox email pipeline stall due to empty recipient address

### DIFF
--- a/server/src/Korga.Core/Korga.Core.csproj
+++ b/server/src/Korga.Core/Korga.Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.11" />
   </ItemGroup>
 
 </Project>

--- a/server/src/Korga.Server/EmailDelivery/EmailDeliveryJobController.cs
+++ b/server/src/Korga.Server/EmailDelivery/EmailDeliveryJobController.cs
@@ -56,8 +56,16 @@ public class EmailDeliveryJobController : OneAtATimeJobController<OutboxEmail>, 
 
             // Don't cancel this operation because messages would sent twice otherwise
             await database.SaveChangesAsync(CancellationToken.None);
-            logger.LogInformation("Delivered email #{Id} to {EmailAddress}",
-                outboxEmail.Id, outboxEmail.EmailAddress);
+
+            if (outboxEmail.InboxEmailId.HasValue)
+            {
+                logger.LogInformation("Delivered inbox email #{InboxEmailId} as #{Id} to {EmailAddress}",
+                    outboxEmail.InboxEmailId, outboxEmail.Id, outboxEmail.EmailAddress);
+            }
+            else
+            {
+                logger.LogInformation("Delivered system email #{Id} to {EmailAddress}", outboxEmail.Id, outboxEmail.EmailAddress);
+            }
         }
         catch (SmtpCommandException ex) when (ex.StatusCode == SmtpStatusCode.MailboxBusy)
         {

--- a/server/src/Korga.Server/EmailDelivery/EmailDeliveryService.cs
+++ b/server/src/Korga.Server/EmailDelivery/EmailDeliveryService.cs
@@ -1,6 +1,7 @@
 ﻿using Korga.Server.Utilities;
 using Microsoft.EntityFrameworkCore;
 using MimeKit;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,6 +21,8 @@ public class EmailDeliveryService
 
     public async ValueTask<bool> Enqueue(string emailAddress, MimeMessage mimeMessage, long? inboxEmailId, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrEmpty(emailAddress)) throw new ArgumentException("The recipient address must not be null or empty", nameof(emailAddress));
+
         if (inboxEmailId.HasValue && await database.OutboxEmails
                 .AnyAsync(email => email.EmailAddress == emailAddress && email.InboxEmailId == inboxEmailId, cancellationToken))
             return false;

--- a/server/src/Korga.Server/EmailRelay/DistributionListService.cs
+++ b/server/src/Korga.Server/EmailRelay/DistributionListService.cs
@@ -44,6 +44,7 @@ public class DistributionListService
                     await database.GroupMembers
                         .Where(m => m.GroupId == groupFilter.GroupId && (groupFilter.GroupRoleId == null || m.GroupRoleId == groupFilter.GroupRoleId))
                         .Join(database.People, m => m.PersonId, p => p.Id, (m, p) => p)
+                        .Where(p => !string.IsNullOrEmpty(p.Email))
                         .ToListAsync(cancellationToken));
             }
             else if (personFilter is StatusFilter statusFilter)
@@ -55,8 +56,9 @@ public class DistributionListService
             }
             else if (personFilter is SinglePerson singlePerson)
             {
-                people.Add(
-                    await database.People.SingleAsync(p => p.Id == singlePerson.PersonId, cancellationToken));
+                people.AddRange(
+                    await database.People.Where(p => p.Id == singlePerson.PersonId && !string.IsNullOrEmpty(p.Email))
+                        .ToListAsync(cancellationToken));
             }
         }
 

--- a/server/src/Korga.Server/Korga.Server.csproj
+++ b/server/src/Korga.Server/Korga.Server.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.1.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-    <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="4.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.9">
+    <PackageReference Include="MailKit" Version="4.2.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
+    <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="4.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.19.0" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.20.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.1" />
   </ItemGroup>

--- a/server/tests/Korga.Server.Tests/Korga.Server.Tests.csproj
+++ b/server/tests/Korga.Server.Tests/Korga.Server.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request fixes #37 which was caused by incomplete filtering in `DistributionListService` which included people in the recipients list with no email address specified in ChurchTools.

I took the chance to update all NuGet packages to their latest release - no major updates though.