### PR TITLE
Service history endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Grant the following permissions to Korga's user:
 - Personen & Gruppen > Sicherheitslevel Personendaten (Stufe 1-3) `churchdb:security level person(1,2,3)`
 - Personen & Gruppen > Alle Personen des jeweiligen Bereiches sichtbar machen (Alle) `churchdb:view alldata(-1)`
 - Personen & Gruppen > Einzelne Gruppen inkl. der enthaltenen Personen sehen (gilt auch für versteckte Gruppen) (Alle) `churchdb:view group(-1)`
+- Events > "Events" sehen `churchservice:view`
+- Events > Dienste einzelner Dienstgruppen einsehen (Alle) `churchservice:view servicegroup(-1)`
+- Events > Events von einzelnen Kalendern sehen (Alle) `churchservice:view events(-1)`
 
 After creating and configuring a ChurchTools user for Korga you can finally configure it via environment variables in `docker-compose.yml`.
 

--- a/server/src/Korga.Core/ChurchTools/Api/Event.cs
+++ b/server/src/Korga.Core/ChurchTools/Api/Event.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Korga.ChurchTools.Api;
+
+public class Event
+{
+    public Event(int id, Guid guid, string name, DateTime startDate, DateTime endDate, List<Service> eventServices)
+    {
+        Id = id;
+        Guid = guid;
+        Name = name;
+        StartDate = startDate;
+        EndDate = endDate;
+        EventServices = eventServices;
+    }
+
+    public int Id { get; }
+    public Guid Guid { get; }
+    public string Name { get; }
+    public DateTime StartDate { get; }
+    public DateTime EndDate { get; }
+    public List<Service> EventServices { get; }
+
+    public class Service
+    {
+        public Service(int id, int? personId, int serviceId, bool agreed)
+        {
+            Id = id;
+            PersonId = personId;
+            ServiceId = serviceId;
+            Agreed = agreed;
+        }
+
+        public int Id { get; }
+        public int? PersonId { get; }
+        public int ServiceId { get; }
+        public bool Agreed { get; }
+    }
+}

--- a/server/src/Korga.Core/ChurchTools/Api/Service.cs
+++ b/server/src/Korga.Core/ChurchTools/Api/Service.cs
@@ -1,0 +1,27 @@
+﻿namespace Korga.ChurchTools.Api;
+
+public class Service
+{
+    public Service(int id, string name, int serviceGroupId, int sortKey, string groupIds, string tagIds)
+    {
+        Id = id;
+        Name = name;
+        ServiceGroupId = serviceGroupId;
+        SortKey = sortKey;
+        GroupIds = groupIds;
+        TagIds = tagIds;
+    }
+
+    public int Id { get; }
+    public string Name { get; }
+    public int ServiceGroupId { get; }
+    public int SortKey { get; }
+    /// <summary>
+    /// Comma separated list of standard groups IDs
+    /// </summary>
+    public string GroupIds { get; }
+    /// <summary>
+    /// Comma separated list of person tag IDs
+    /// </summary>
+    public string TagIds { get; }
+}

--- a/server/src/Korga.Core/ChurchTools/Api/ServiceGroup.cs
+++ b/server/src/Korga.Core/ChurchTools/Api/ServiceGroup.cs
@@ -1,0 +1,15 @@
+﻿namespace Korga.ChurchTools.Api;
+
+public class ServiceGroup
+{
+    public ServiceGroup(int id, string name, int sortKey)
+    {
+        Id = id;
+        Name = name;
+        SortKey = sortKey;
+    }
+
+    public int Id { get; }
+    public string Name { get; }
+    public int SortKey { get; }
+}

--- a/server/src/Korga.Core/ChurchTools/ChurchToolsApi.cs
+++ b/server/src/Korga.Core/ChurchTools/ChurchToolsApi.cs
@@ -92,12 +92,9 @@ public class ChurchToolsApi : IChurchToolsApi, IDisposable
         return InternalGetAllPages<Group>("/api/groups", query.ToString(), cancellationToken);
     }
 
-    public async ValueTask<List<GroupMember>> GetGroupMembers(CancellationToken cancellationToken = default)
+    public ValueTask<List<GroupMember>> GetGroupMembers(CancellationToken cancellationToken = default)
     {
-        Response<List<GroupMember>> groupMembers = await httpClient.GetFromJsonAsync<Response<List<GroupMember>>>("/api/groups/members", cancellationToken)
-            ?? throw new InvalidDataException();
-
-        return groupMembers.Data;
+        return InternalGetNonPaged<List<GroupMember>>("/api/groups/members", cancellationToken);
     }
 
     public ValueTask<List<Person>> GetPeople(CancellationToken cancellationToken = default)
@@ -105,41 +102,58 @@ public class ChurchToolsApi : IChurchToolsApi, IDisposable
         return InternalGetAllPages<Person>("/api/persons", null, cancellationToken);
     }
 
-    public async ValueTask<Person> GetPerson(CancellationToken cancellationToken = default)
+    public ValueTask<Person> GetPerson(CancellationToken cancellationToken = default)
     {
-        Response<Person> person = await httpClient.GetFromJsonAsync<Response<Person>>("/api/whoami", cancellationToken)
-            ?? throw new InvalidDataException();
-
-        return person.Data;
+        return InternalGetNonPaged<Person>("/api/whoami", cancellationToken);
     }
 
-    public async ValueTask<Person> GetPerson(int personId, CancellationToken cancellationToken = default)
+    public ValueTask<Person> GetPerson(int personId, CancellationToken cancellationToken = default)
     {
-        Response<Person> person = await httpClient.GetFromJsonAsync<Response<Person>>($"/api/persons/{personId}", cancellationToken)
-            ?? throw new InvalidDataException();
-
-        return person.Data;
+        return InternalGetNonPaged<Person>($"/api/persons/{personId}", cancellationToken);
     }
 
-    public async ValueTask<string> GetPersonLoginToken(int personId, CancellationToken cancellationToken = default)
+    public ValueTask<string> GetPersonLoginToken(int personId, CancellationToken cancellationToken = default)
     {
-        Response<string> loginToken = await httpClient.GetFromJsonAsync<Response<string>>($"/api/persons/{personId}/logintoken", cancellationToken)
-            ?? throw new InvalidDataException();
-
-        return loginToken.Data;
+        return InternalGetNonPaged<string>($"/api/persons/{personId}/logintoken", cancellationToken);
     }
 
-    public async ValueTask<PersonMasterdata> GetPersonMasterdata(CancellationToken cancellationToken = default)
+    public ValueTask<PersonMasterdata> GetPersonMasterdata(CancellationToken cancellationToken = default)
     {
-        Response<PersonMasterdata> personMasterdata = await httpClient.GetFromJsonAsync<Response<PersonMasterdata>>("/api/person/masterdata", cancellationToken)
-            ?? throw new InvalidDataException();
+        return InternalGetNonPaged<PersonMasterdata>("/api/person/masterdata", cancellationToken);
+    }
 
-        return personMasterdata.Data;
+    public ValueTask<List<Service>> GetServices(CancellationToken cancellationToken = default)
+    {
+        return InternalGetNonPaged<List<Service>>("/api/services", cancellationToken);
+    }
+
+    public ValueTask<Service> GetService(int serviceId, CancellationToken cancellationToken = default)
+    {
+        return InternalGetNonPaged<Service>($"/api/services/{serviceId}", cancellationToken);
+    }
+
+    public ValueTask<List<ServiceGroup>> GetServiceGroups(CancellationToken cancellationToken = default)
+    {
+        return InternalGetNonPaged<List<ServiceGroup>>("/api/servicegroups", cancellationToken);
+    }
+
+    public ValueTask<List<Event>> GetEvents(DateOnly from, DateOnly to, CancellationToken cancellationToken = default)
+    {
+        string path = $"/api/events?from={from:yyyy-MM-dd}&to={to:yyyy-MM-dd}&include=eventServices";
+        return InternalGetNonPaged<List<Event>>(path, cancellationToken);
     }
 
     public void Dispose()
     {
         httpClient.Dispose();
+    }
+
+    private async ValueTask<T> InternalGetNonPaged<T>(string path, CancellationToken cancellationToken)
+    {
+        Response<T> response = await httpClient.GetFromJsonAsync<Response<T>>(path, cancellationToken)
+            ?? throw new InvalidDataException($"ChurchTools endpoint {path} returned an invalid response");
+
+        return response.Data;
     }
 
     private async ValueTask<List<T>> InternalGetAllPages<T>(string path, string? query, CancellationToken cancellationToken)

--- a/server/src/Korga.Core/ChurchTools/IChurchToolsApi.cs
+++ b/server/src/Korga.Core/ChurchTools/IChurchToolsApi.cs
@@ -17,4 +17,8 @@ public interface IChurchToolsApi : IDisposable
 	ValueTask<Person> GetPerson(int personId, CancellationToken cancellationToken = default);
 	ValueTask<string> GetPersonLoginToken(int personId, CancellationToken cancellationToken = default);
 	ValueTask<PersonMasterdata> GetPersonMasterdata(CancellationToken cancellationToken = default);
+    ValueTask<List<Service>> GetServices(CancellationToken cancellationToken = default);
+    ValueTask<Service> GetService(int serviceId, CancellationToken cancellationToken = default);
+    ValueTask<List<ServiceGroup>> GetServiceGroups(CancellationToken cancellationToken = default);
+    ValueTask<List<Event>> GetEvents(DateOnly from, DateOnly to, CancellationToken cancellationToken = default);
 }

--- a/server/src/Korga.Server/Controllers/ServiceController.cs
+++ b/server/src/Korga.Server/Controllers/ServiceController.cs
@@ -1,0 +1,89 @@
+﻿using Korga.ChurchTools;
+using Korga.ChurchTools.Api;
+using Korga.Server.Models.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Korga.Server.Controllers;
+
+[Authorize]
+[ApiController]
+public class ServiceController : ControllerBase
+{
+    private readonly DatabaseContext database;
+    private readonly IChurchToolsApi churchTools;
+
+    public ServiceController(DatabaseContext database, IChurchToolsApi churchTools)
+    {
+        this.database = database;
+        this.churchTools = churchTools;
+    }
+
+    [HttpGet("~/api/services")]
+    [ProducesResponseType(typeof(ServiceResponse[]), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetServices()
+    {
+        var serviceGroupsTask = churchTools.GetServiceGroups();
+        var servicesTask = churchTools.GetServices();
+
+        List<ServiceGroup> serviceGroups = await serviceGroupsTask;
+        List<Service> services = await servicesTask;
+
+        return new JsonResult(services.Select(service => new ServiceResponse
+        {
+            Id = service.Id,
+            Name = service.Name,
+            ServiceGroupName = serviceGroups.Find(g => g.Id == service.ServiceGroupId)?.Name
+        }));
+    }
+
+    [HttpGet("~/api/services/{id}/history")]
+    [ProducesResponseType(typeof(ServiceHistoryResponse[]), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetServiceHistory(int id, [FromQuery] DateOnly? from, [FromQuery] DateOnly? to)
+    {
+        Service service = await churchTools.GetService(id);
+        List<int> groupIds = service.GroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(int.Parse)
+            .ToList();
+
+        var people = await
+            (from member in database.GroupMembers.Where(member => groupIds.Contains(member.GroupId))
+             join person in database.People on member.PersonId equals person.Id
+             select new ServiceHistoryResponse
+             {
+                 PersonId = person.Id,
+                 FirstName = person.FirstName,
+                 LastName = person.LastName
+             })
+            .Distinct()
+            .ToDictionaryAsync(x => x.PersonId);
+
+        from ??= DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-12));
+        to ??= DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(3));
+
+        List<Event> events = await churchTools.GetEvents(from.Value, to.Value);
+        foreach (Event @event in events)
+        {
+            foreach (Event.Service eventService in @event.EventServices)
+            {
+                if (eventService.ServiceId == id
+                    && eventService.PersonId.HasValue
+                    && eventService.Agreed
+                    && people.TryGetValue(eventService.PersonId.Value, out var person))
+                {
+                    person.ServiceDates.Add(DateOnly.FromDateTime(@event.StartDate));
+                }
+            }
+        }
+
+        List<ServiceHistoryResponse> peopleList = people.Values.ToList();
+        peopleList.Sort((a, b) => a.ServiceDates.LastOrDefault().CompareTo(b.ServiceDates.LastOrDefault()));
+        return new JsonResult(peopleList);
+    }
+}

--- a/server/src/Korga.Server/Models/Json/ServiceHistoryResponse.cs
+++ b/server/src/Korga.Server/Models/Json/ServiceHistoryResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Korga.Server.Models.Json;
+
+public class ServiceHistoryResponse
+{
+    public required int PersonId { get; init; }
+    public required string FirstName { get; init; }
+    public required string LastName { get; init; }
+    public List<DateOnly> ServiceDates { get; } = new();
+}

--- a/server/src/Korga.Server/Models/Json/ServiceResponse.cs
+++ b/server/src/Korga.Server/Models/Json/ServiceResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Korga.Server.Models.Json;
+
+public class ServiceResponse
+{
+    public required int Id { get; init; }
+    public required string Name { get; init; }
+    public string? ServiceGroupName { get; init; }
+}

--- a/server/tests/Korga.Server.Tests/ChurchToolsSyncServiceTests.cs
+++ b/server/tests/Korga.Server.Tests/ChurchToolsSyncServiceTests.cs
@@ -289,5 +289,25 @@ public class ChurchToolsSyncServiceTests : DatabaseTestBase
             else
                 return ValueTask.FromResult(PersonMasterdata);
         }
+
+        public ValueTask<List<Service>> GetServices(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ValueTask<Service> GetService(int serviceId, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ValueTask<List<ServiceGroup>> GetServiceGroups(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ValueTask<List<Event>> GetEvents(DateOnly from, DateOnly to, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
This pull request adds two new endpoints for service history analysis. It requires OpenID Connect authentication however does not use additional authorization. That means everyone with a ChurchTools login can access these endpoints.

Performance strongly depends on the backend's internet connection as it fetches more than 2MB JSON from ChurchTools. The database cache is only used for group membership and person lookup.

A UI for this feature should be implemented in a separate pull request.