### PR TITLE
Fix an exception for services with no groups associated

### DIFF
--- a/server/src/Korga.Core/ChurchTools/Api/Service.cs
+++ b/server/src/Korga.Core/ChurchTools/Api/Service.cs
@@ -19,9 +19,9 @@ public class Service
     /// <summary>
     /// Comma separated list of standard groups IDs
     /// </summary>
-    public string GroupIds { get; }
+    public string? GroupIds { get; }
     /// <summary>
     /// Comma separated list of person tag IDs
     /// </summary>
-    public string TagIds { get; }
+    public string? TagIds { get; }
 }

--- a/server/src/Korga.Core/Korga.Core.csproj
+++ b/server/src/Korga.Core/Korga.Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.13" />
   </ItemGroup>
 
 </Project>

--- a/server/src/Korga.Server/Controllers/ServiceController.cs
+++ b/server/src/Korga.Server/Controllers/ServiceController.cs
@@ -48,6 +48,9 @@ public class ServiceController : ControllerBase
     public async Task<IActionResult> GetServiceHistory(int id, [FromQuery] DateOnly? from, [FromQuery] DateOnly? to)
     {
         Service service = await churchTools.GetService(id);
+
+        if (service.GroupIds == null) return new JsonResult(Array.Empty<ServiceHistoryResponse>());
+
         List<int> groupIds = service.GroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(int.Parse)
             .ToList();

--- a/server/src/Korga.Server/Korga.Server.csproj
+++ b/server/src/Korga.Server/Korga.Server.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="MailKit" Version="4.2.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
     <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="4.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/server/tests/Korga.Server.Tests/Korga.Server.Tests.csproj
+++ b/server/tests/Korga.Server.Tests/Korga.Server.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit" Version="2.6.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request fixes an exception when querying the history for services that do not have any groups associated to them.