### PR TITLE
Respect GroupMemberStatus for services list

### DIFF
--- a/server/src/Korga.Core/ChurchTools/Api/GroupMember.cs
+++ b/server/src/Korga.Core/ChurchTools/Api/GroupMember.cs
@@ -2,16 +2,18 @@
 
 public class GroupMember : IIdentifiable<long>
 {
-	public GroupMember(int personId, int groupId, int groupTypeRoleId)
+	public GroupMember(int personId, int groupId, int groupTypeRoleId, string groupMemberStatus)
 	{
 		PersonId = personId;
 		GroupId = groupId;
 		GroupTypeRoleId = groupTypeRoleId;
+        GroupMemberStatus = groupMemberStatus;
 	}
 
 	public int PersonId { get; set; }
     public int GroupId { get; set; }
     public int GroupTypeRoleId { get; set; }
+    public string GroupMemberStatus { get; set; }
 
 	long IIdentifiable<long>.Id => (((long)PersonId) << 32) | (long)GroupId;
 }

--- a/server/src/Korga.Core/ChurchTools/Entities/GroupMember.cs
+++ b/server/src/Korga.Core/ChurchTools/Entities/GroupMember.cs
@@ -2,7 +2,7 @@
 
 public class GroupMember : IIdentifiable<long>
 {
-	public int PersonId { get; set; }
+    public int PersonId { get; set; }
 	public Person? Person { get; set; }
 
 	public int GroupId { get; set; }
@@ -10,6 +10,8 @@ public class GroupMember : IIdentifiable<long>
 
 	public int GroupRoleId { get; set; }
 	public GroupRole? GroupRole { get; set; }
+
+    public GroupMemberStatus GroupMemberStatus { get; set; }
 
 	long IIdentifiable<long>.Id => (((long)PersonId) << 32) | (long)GroupId;
 }

--- a/server/src/Korga.Core/ChurchTools/GroupMemberStatus.cs
+++ b/server/src/Korga.Core/ChurchTools/GroupMemberStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace Korga.ChurchTools;
+
+public enum GroupMemberStatus
+{
+    Active,
+    Requested,
+    ToDelete
+}

--- a/server/src/Korga.Core/DatabaseContext.cs
+++ b/server/src/Korga.Core/DatabaseContext.cs
@@ -63,6 +63,7 @@ public sealed class DatabaseContext : DbContext
         groupMember.HasOne(gm => gm.Person).WithMany().HasForeignKey(gm => gm.PersonId);
         groupMember.HasOne(gm => gm.Group).WithMany().HasForeignKey(gm => gm.GroupId);
         groupMember.HasOne(gm => gm.GroupRole).WithMany().HasForeignKey(gm => gm.GroupRoleId);
+        groupMember.Property(gm => gm.GroupMemberStatus).HasConversion<int>();
 
         var groupType = modelBuilder.Entity<GroupType>();
         groupType.HasKey(x => x.Id);

--- a/server/src/Korga.Server/Controllers/ServiceController.cs
+++ b/server/src/Korga.Server/Controllers/ServiceController.cs
@@ -62,7 +62,8 @@ public class ServiceController : ControllerBase
              {
                  PersonId = person.Id,
                  FirstName = person.FirstName,
-                 LastName = person.LastName
+                 LastName = person.LastName,
+                 GroupMemberStatus = member.GroupMemberStatus,
              })
             .Distinct()
             .ToDictionaryAsync(x => x.PersonId);

--- a/server/src/Korga.Server/Migrations/20240115151648_GroupMemberStatus.Designer.cs
+++ b/server/src/Korga.Server/Migrations/20240115151648_GroupMemberStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Korga;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Korga.Server.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20240115151648_GroupMemberStatus")]
+    partial class GroupMemberStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/Korga.Server/Migrations/20240115151648_GroupMemberStatus.cs
+++ b/server/src/Korga.Server/Migrations/20240115151648_GroupMemberStatus.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Korga.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class GroupMemberStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GroupMemberStatus",
+                table: "GroupMembers",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GroupMemberStatus",
+                table: "GroupMembers");
+        }
+    }
+}

--- a/server/src/Korga.Server/Models/Json/ServiceHistoryResponse.cs
+++ b/server/src/Korga.Server/Models/Json/ServiceHistoryResponse.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Korga.ChurchTools;
+using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Korga.Server.Models.Json;
 
@@ -8,5 +10,9 @@ public class ServiceHistoryResponse
     public required int PersonId { get; init; }
     public required string FirstName { get; init; }
     public required string LastName { get; init; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public required GroupMemberStatus GroupMemberStatus { get; init; }
+
     public List<DateOnly> ServiceDates { get; } = new();
 }

--- a/webapp/src/services/service.ts
+++ b/webapp/src/services/service.ts
@@ -10,6 +10,7 @@ export interface ServiceHistory {
   personId: number;
   firstName: string;
   lastName: string;
+  groupMemberStatus: "Active" | "Requested" | "ToDelete";
   serviceDates: string[];
 }
 

--- a/webapp/src/views/ServiceList.vue
+++ b/webapp/src/views/ServiceList.vue
@@ -27,7 +27,14 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(person, index) in serviceHistory" :key="index">
+        <tr
+          v-for="(person, index) in serviceHistory"
+          :key="index"
+          :class="{
+            requested: person.groupMemberStatus === 'Requested',
+            todelete: person.groupMemberStatus === 'ToDelete',
+          }"
+        >
           <th scope="row">{{ index }}</th>
           <td>{{ person.firstName }}</td>
           <td>{{ person.lastName }}</td>
@@ -59,4 +66,13 @@ const fetchServiceHistory = async function (id: number) {
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+tr.requested td {
+  color: var(--bs-secondary);
+}
+
+tr.todelete td {
+  color: var(--bs-danger);
+  text-decoration: line-through;
+}
+</style>


### PR DESCRIPTION
This pull request adds synchronization for GroupMemberStatus from ChurchTools. This information is exposed via the `/api/services/{id}/history` endpoint and shown in different colors in the frontend which fixes #53.

The database migration simply adds another column to the `GroupMembers` table with all members being active by default. Because it is fully generated and simple, I refrained from separate unit tests.