### PR TITLE
Fix memory leak at outbox email queueing

### DIFF
--- a/server/Korga/EmailDelivery/EmailDeliveryJobController.cs
+++ b/server/Korga/EmailDelivery/EmailDeliveryJobController.cs
@@ -38,10 +38,8 @@ public class EmailDeliveryJobController : OneAtATimeJobController<OutboxEmail>, 
     {
         SmtpClient smtp = await GetConnection(cancellationToken);
 
-        MimeMessage mimeMessage;
-
-        using (MemoryStream memoryStream = new(outboxEmail.Content))
-            mimeMessage = MimeMessage.Load(memoryStream, CancellationToken.None);
+        using MemoryStream memoryStream = new(outboxEmail.Content);
+        using MimeMessage mimeMessage = MimeMessage.Load(memoryStream, CancellationToken.None);
 
         try
         {

--- a/server/Korga/EmailDelivery/EmailDeliveryService.cs
+++ b/server/Korga/EmailDelivery/EmailDeliveryService.cs
@@ -44,7 +44,6 @@ public class EmailDeliveryService
         // Without this line, Korga takes gigabytes of memory when sending large messages to many recipients
         database.Entry(outboxEmail).State = EntityState.Detached;
 
-        var entries = database.ChangeTracker.Entries();
         jobQueue.EnsureRunning();
         return true;
     }


### PR DESCRIPTION
This pull request most importantly disables change tracking for `OutboxEmail` entities after inserting them into the database. Without doing so, EF Core would sustain a reference to the entity thereby inhibiting its garbage collection. With a large distribution list of 250 members with a 12 MB large email (default limit) this results in a memory usage of 3 GiB without overhead only for `OutboxEmail` entities which quickly leads to out of memory scenarios.

Generally, it was not a very clever conceptual choice to store email data in MariaDB. Changing this however would take too long now can therefore be discussed in #65.

With this pull request Korga peaks at ~800 MiB memory usage in the scenario described above which is acceptable to me for now.