### PR TITLE
Fix handling of emails with missing headers

### DIFF
--- a/Korga.sln
+++ b/Korga.sln
@@ -15,7 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{28945597-DB66-4C
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{2ED6D7FB-8B8A-4139-98C3-854E00A38490}"
 	ProjectSection(SolutionItems) = preProject
-		docs\docker-compose.yml = docs\docker-compose.yml
+		docs\compose.yaml = docs\compose.yaml
 		docs\email-processing-pipeline.md = docs\email-processing-pipeline.md
 		docs\frontend.md = docs\frontend.md
 	EndProjectSection

--- a/server/Korga.Tests/Migrations/09_PersonFilterList/DatabaseContext.cs
+++ b/server/Korga.Tests/Migrations/09_PersonFilterList/DatabaseContext.cs
@@ -6,6 +6,7 @@ public class DatabaseContext : DbContext
 {
     public DatabaseContext(DbContextOptions<DatabaseContext> options) : base(options) { }
 
+    public DbSet<InboxEmail> InboxEmails => Set<InboxEmail>();
     public DbSet<DistributionList> DistributionLists => Set<DistributionList>();
     public DbSet<PersonFilterList> PersonFilterLists => Set<PersonFilterList>();
     public DbSet<PersonFilter> PersonFilters => Set<PersonFilter>();

--- a/server/Korga.Tests/Migrations/09_PersonFilterList/InboxEmail.cs
+++ b/server/Korga.Tests/Migrations/09_PersonFilterList/InboxEmail.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Korga.Tests.Migrations.PersonFilterList;
+
+public class InboxEmail
+{
+    public long Id { get; set; }
+
+    public long? DistributionListId { get; set; }
+    public DistributionList? DistributionList { get; set; }
+
+    public uint? UniqueId { get; set; }
+    public required string Subject { get; set; }
+    public required string From { get; set; }
+    public string? Sender { get; set; }
+    public string? ReplyTo { get; set; }
+    public required string To { get; set; }
+    public string? Receiver { get; set; }
+    public byte[]? Header { get; set; }
+    public byte[]? Body { get; set; }
+    public DateTime DownloadTime { get; set; }
+    public DateTime ProcessingCompletedTime { get; set; }
+}

--- a/server/Korga.Tests/Migrations/10_NullableEmailHeaders/DatabaseContext.cs
+++ b/server/Korga.Tests/Migrations/10_NullableEmailHeaders/DatabaseContext.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Korga.Tests.Migrations.NullableEmailHeaders;
+
+public class DatabaseContext : DbContext
+{
+    public DatabaseContext(DbContextOptions<DatabaseContext> options) : base(options) { }
+
+    public DbSet<InboxEmail> InboxEmails => Set<InboxEmail>();
+}

--- a/server/Korga.Tests/Migrations/10_NullableEmailHeaders/InboxEmail.cs
+++ b/server/Korga.Tests/Migrations/10_NullableEmailHeaders/InboxEmail.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Korga.Tests.Migrations.NullableEmailHeaders;
+
+public class InboxEmail
+{
+    public long Id { get; set; }
+
+    public long? DistributionListId { get; set; }
+
+    public uint? UniqueId { get; set; }
+    public string? Subject { get; set; }
+    public string? From { get; set; }
+    public string? Sender { get; set; }
+    public string? ReplyTo { get; set; }
+    public string? To { get; set; }
+    public string? Receiver { get; set; }
+    public byte[]? Header { get; set; }
+    public byte[]? Body { get; set; }
+    public DateTime DownloadTime { get; set; }
+    public DateTime ProcessingCompletedTime { get; set; }
+}

--- a/server/Korga.Tests/Migrations/10_NullableEmailHeadersMigrationTests.cs
+++ b/server/Korga.Tests/Migrations/10_NullableEmailHeadersMigrationTests.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Korga.Tests.Migrations;
+
+public class NullableEmailHeadersMigrationTests : MigrationTestBase<PersonFilterList.DatabaseContext, NullableEmailHeaders.DatabaseContext>
+{
+    public NullableEmailHeadersMigrationTests(ITestOutputHelper testOutput) : base(testOutput) { }
+
+    [Fact]
+    public async Task TestUpgrade()
+    {
+        PersonFilterList.InboxEmail reference = new()
+        {
+            Id = 1,
+            Subject = "Test",
+            From = "alice@example.org",
+            To = "bob@example.org",
+        };
+        PersonFilterList.InboxEmail emptyFields = new()
+        {
+            Id = 2,
+            Subject = string.Empty,
+            From = string.Empty,
+            To = string.Empty,
+        };
+        IMigrator migrator = databaseContext.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        // Create database schema of last migration before the one to test
+        await migrator.MigrateAsync("PersonFilterList");
+
+        // Add test data
+        before.InboxEmails.Add(reference);
+        before.InboxEmails.Add(emptyFields);
+        await before.SaveChangesAsync();
+
+        // Run migration at test
+        await migrator.MigrateAsync("NullableEmailHeaders");
+
+        // Verify that data has been migrated as expected
+        List<NullableEmailHeaders.InboxEmail> inboxEmails = await after.InboxEmails.ToListAsync();
+        Assert.Contains(inboxEmails, email => email.Id == reference.Id);
+        Assert.Contains(inboxEmails, email => email.Id == emptyFields.Id);
+        Assert.Equal(2, inboxEmails.Count);
+    }
+
+    [Fact]
+    public async Task TestDowngrade()
+    {
+        NullableEmailHeaders.InboxEmail reference = new()
+        {
+            Id = 1,
+            Subject = "Test",
+            From = "alice@example.org",
+            To = "bob@example.org",
+        };
+        NullableEmailHeaders.InboxEmail emptyFields = new()
+        {
+            Id = 2,
+            Subject = string.Empty,
+            From = string.Empty,
+            To = string.Empty,
+        };
+        NullableEmailHeaders.InboxEmail nullSubject = new()
+        {
+            Id = 3,
+            Subject = null,
+            From = "alice@example.org",
+            To = "bob@example.org",
+        };
+        NullableEmailHeaders.InboxEmail nullFrom = new()
+        {
+            Id = 4,
+            Subject = "Test",
+            From = null,
+            To = "bob@example.org",
+        };
+        NullableEmailHeaders.InboxEmail nullTo = new()
+        {
+            Id = 5,
+            Subject = "Test",
+            From = "alice@example.org",
+            To = null,
+        };
+        IMigrator migrator = databaseContext.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        // Create database schema of the migration to test
+        await migrator.MigrateAsync("NullableEmailHeaders");
+
+        // Add test data
+        after.InboxEmails.Add(reference);
+        after.InboxEmails.Add(emptyFields);
+        after.InboxEmails.Add(nullSubject);
+        after.InboxEmails.Add(nullFrom);
+        after.InboxEmails.Add(nullTo);
+        await after.SaveChangesAsync();
+
+        // Reset change tracker before upgrading the schema again to avoid caching
+        after.ChangeTracker.Clear();
+
+        // Migrate to migration before the one to test and thereby revert it
+        await migrator.MigrateAsync("PersonFilterList");
+
+        // Verify that data has been migrated as expected
+        List<PersonFilterList.InboxEmail> inboxEmails = await before.InboxEmails.ToListAsync();
+        Assert.Contains(inboxEmails, email => email.Id == reference.Id);
+        Assert.Contains(inboxEmails, email => email.Id == emptyFields.Id);
+        Assert.DoesNotContain(inboxEmails, email => email.Id == nullSubject.Id);
+        Assert.DoesNotContain(inboxEmails, email => email.Id == nullFrom.Id);
+        Assert.DoesNotContain(inboxEmails, email => email.Id == nullTo.Id);
+        Assert.Equal(2, inboxEmails.Count);
+
+        // Upgrade database again to verify rollback worked
+        await migrator.MigrateAsync("NullableEmailHeaders");
+    }
+}

--- a/server/Korga/EmailRelay/Entities/InboxEmail.cs
+++ b/server/Korga/EmailRelay/Entities/InboxEmail.cs
@@ -4,7 +4,7 @@ namespace Korga.EmailRelay.Entities;
 
 public class InboxEmail
 {
-    public InboxEmail(uint? uniqueId, string subject, string from, string? sender, string? replyTo, string to, string? receiver, byte[]? header, byte[]? body)
+    public InboxEmail(uint? uniqueId, string? subject, string? from, string? sender, string? replyTo, string? to, string? receiver, byte[]? header, byte[]? body)
     {
         UniqueId = uniqueId;
         Subject = subject;
@@ -23,11 +23,11 @@ public class InboxEmail
     public DistributionList? DistributionList { get; set; }
 
     public uint? UniqueId { get; set; }
-    public string Subject { get; set; }
-    public string From { get; set; }
+    public string? Subject { get; set; }
+    public string? From { get; set; }
     public string? Sender { get; set; }
     public string? ReplyTo { get; set; }
-    public string To { get; set; }
+    public string? To { get; set; }
     /// <summary>
     /// The mailbox this email was delivered to via SMTP.
     /// Determined by <c>Received</c>, <c>Envelope-To</c> or <c>X-Envelope-To</c> headers.

--- a/server/Korga/EmailRelay/ImapReceiverService.cs
+++ b/server/Korga/EmailRelay/ImapReceiverService.cs
@@ -96,8 +96,10 @@ public class ImapReceiverService
                 bodyContent = memoryStream.ToArray();
         }
 
-        string from = message.Headers[HeaderId.From];
-        string to = message.Headers[HeaderId.To];
+        // According to RFC 5322 section 3.6, the Orig-Date and From headers are required
+        // In case of missing headers, the message will be rejected in the next pipeline step
+        string? from = message.Headers[HeaderId.From];
+        string? to = message.Headers[HeaderId.To];
         string? receiver = message.Headers.GetReceiver();
 
         InboxEmail emailEntity = new(

--- a/server/Korga/Migrations/20250101221549_NullableEmailHeaders.Designer.cs
+++ b/server/Korga/Migrations/20250101221549_NullableEmailHeaders.Designer.cs
@@ -4,6 +4,7 @@ using Korga;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Korga.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250101221549_NullableEmailHeaders")]
+    partial class NullableEmailHeaders
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/Korga/Migrations/20250101221549_NullableEmailHeaders.cs
+++ b/server/Korga/Migrations/20250101221549_NullableEmailHeaders.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Korga.Migrations
+{
+    /// <inheritdoc />
+    public partial class NullableEmailHeaders : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "To",
+                table: "InboxEmails",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Subject",
+                table: "InboxEmails",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "From",
+                table: "InboxEmails",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "InboxEmails",
+                keyColumn: "To",
+                keyValue: null);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "To",
+                table: "InboxEmails",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.DeleteData(
+                table: "InboxEmails",
+                keyColumn: "Subject",
+                keyValue: null);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Subject",
+                table: "InboxEmails",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.DeleteData(
+                table: "InboxEmails",
+                keyColumn: "From",
+                keyValue: null);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "From",
+                table: "InboxEmails",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}


### PR DESCRIPTION
This pull request fixes #74.

Emails without `Subject` or `To` no longer cause Korga's email pipeline to stall. Although, emails must have a `From` header as of RFC 5322 section 3.6, I do not trust all email server to enforce this and also handle the case that the `From` header is missing.

For review it may be easier to separately look at semantic changes (b5d08265aabffa8f06648e1475886d28fc66e450) and the database migration with related tests.